### PR TITLE
Feature/dockerize app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Environment variable file
+.env
 # History files
 .Rhistory
 .Rapp.history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rocker/tidyverse:3.6.1 as base
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    libxml2-dev \
+    libgit2-dev \
+    libpng-dev \
+    libudunits2-dev \
+    libgdal-dev \
+    ca-certificates
+
+RUN R -e "install.packages(c('rlang','shiny', 'shinythemes', 'shinyjs', 'shinycssloaders', 'shinyBS', 'tidycensus' , 'assertr', 'flexdashboard', 'httr'), repos='http://cran.rstudio.com/')"
+RUN R -e "install.packages('git2r', type='source', configure.vars='autobrew=yes')"
+RUN R -e "devtools::install_github('rstudio/renv')"
+RUN R -e "install.packages(c('aws.signature', 'aws.ec2metadata', 'aws.s3'), repos = c(cloudyr = 'http://cloudyr.github.io/drat', getOption('repos')))"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
 # covid_risk_score
 An interactive dashboard for users to calculate their individualized risk score of contracting COVID-19
 
-# Get started
-Step 1. We use New York Times COVID data as an dependency. Please clone their repo to the /data folder
-        git clone https://github.com/nytimes/covid-19-data.git
+# DockerShinyApp
 
-Step 2. The main app is in app.R, click "Run app" to launch
+## Installing
+This project is built to use Docker and docker-compose to make development easy across all machines and remove host machine configuration as a potential issue.  Use `docker-compose` to get started quickly.  You will need to install docker and docker-compose. 
+
+* [Docker](https://docs.docker.com/install/)
+* [Docker Compose](https://docs.docker.com/compose/install/)
+
+Use docker-compose to build the image:
+```
+docker-compose build
+```
+
+Remember that docker images are immutable once built.  Only changes to files in `/home/rstudio` will persist after restarts. 
+
+## Development
+To create an RStudio environment preloaded with all dependencies
+1. Create a `.env` file that defines the desired RStudio password, e.g.
+```
+PASSWORD=mystrongpassword
+```
+There is an example [sample.env](sample.env) you can also use.  Copy it and rename it to `.env`. 
+
+2. Start the environment
+`docker-compose up`
+
+3. Visit `http://localhost:8787` and start hacking.
+
+4. Keep shiny app code in `app.R`.  Launch it for development with `shiny::runApp('app.R')`.
+
+## Deployment
+TBD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  rstudio:
+    environment:
+    #  - ADD=SHINY
+      - PASSWORD=${PASSWORD}
+    build: .
+    volumes:
+      - .:/home/rstudio
+      - ~/.aws:/home/rstudio/.aws
+
+    ports:
+     - '8787:8787' # Rstudio
+     - '8080:8080'
+     #- '3838:3838' # Shiny

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,1 @@
+PASSWORD=mystrongpassword

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,0 +1,47 @@
+FROM rocker/shiny-verse:3.6.1 AS base
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+    libxml2-dev \
+    libgit2-dev \
+    libpng-dev \
+    libudunits2-dev \
+    libgdal-dev \
+    ca-certificates \
+    curl \
+    awscli \
+    && R -e "install.packages(c('rlang','shiny', 'shinythemes', 'shinyjs', 'shinycssloaders', 'shinyBS', 'tidycensus' , 'assertr', 'flexdashboard', 'httr'), repos='http://cran.rstudio.com/')" \
+    && R -e "install.packages('git2r', type='source', configure.vars='autobrew=yes')" \
+    && R -e "devtools::install_github('rstudio/renv')" \
+    && R -e "install.packages(c('aws.signature', 'aws.ec2metadata', 'aws.s3'), repos = c(cloudyr = 'http://cloudyr.github.io/drat', getOption('repos')))"
+
+RUN printf 'run_as shiny;\n\
+server {\n\
+  listen 3838;\n\
+  location / {\n\
+    app_dir /srv/shiny-server/CommunityConnectorDockerShinyApp;\n\
+    log_dir /var/log/shiny-server;\n\
+  }\n\
+}\n' > /etc/shiny-server/shiny-server.conf \
+    && rm -r /srv/shiny-server/sample-apps
+
+# TODO: update copy location
+COPY app/ /srv/shiny-server/CommunityConnectorDockerShinyApp/
+
+WORKDIR /root
+
+RUN printf '#!/bin/sh\n\
+mkdir -p /var/log/shiny-server\n\
+chown shiny.shiny /var/log/shiny-server\n\
+if [ "$APPLICATION_LOGS_TO_STDOUT" != "false" ];\n\
+then\n\
+    # push the "real" application logs to stdout with xtail in detached mode\n\
+    exec xtail /var/log/shiny-server/ &\n\
+fi\n\
+echo "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" > /home/shiny/.Renviron\n\
+chown shiny:shiny /home/shiny/.Renviron\n\
+# start shiny server\n\
+exec shiny-server 2>&1\n' > start.sh \
+  && chmod +x start.sh
+
+CMD ["/root/start.sh"]


### PR DESCRIPTION
- Add Dockerfile and docker-compose.yml to develop app in Docker container
- No longer clones entire https://github.com/nytimes/covid-19-data.git repo, only downloads the county data
- Updated README for instructions on how to use Docker to develop and leave section for instructions on deployment