### PR TITLE
Feature/116 post covid condition info

### DIFF
--- a/app/global.R
+++ b/app/global.R
@@ -32,6 +32,7 @@ urls  = list(
   cdc_mm6909e1 = "https://www.cdc.gov/mmwr/volumes/69/wr/pdfs/mm6909e1-H.pdf",
   cdc_mm6912e2 = "https://www.cdc.gov/mmwr/volumes/69/wr/mm6912e2.htm",
   cdc_mm6913e2 = "https://www.cdc.gov/mmwr/volumes/69/wr/mm6913e2.htm",
+  cdc_post_covid_conditions = "https://www.cdc.gov/coronavirus/2019-ncov/long-term-effects.html",
   cdc_ppe = "https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/cloth-face-cover-guidance.html",
   cdc_prevention = "https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html",
   cdc_symptoms = "https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html",

--- a/app/info_html.R
+++ b/app/info_html.R
@@ -135,7 +135,7 @@ renderMethodsHtml <- function() {
     ), # end of ol
     tags$p(""),
     #tags$p("We'll be doing our best to update these assumptions as additional knowledge about the virus becomes available."),
-    tags$h4("In the Works [or Features/Updates to Come]"),
+    tags$h4("In the Works:"),
     tags$ul(
       tags$p("We are continuously working to update these assumptions as additional knowledge about the virus becomes available."),
       tags$p("Below are some COVID-19 developments we are monitoring closely and are looking to incoporate into the methodology as data become available."),

--- a/app/info_html.R
+++ b/app/info_html.R
@@ -141,7 +141,7 @@ renderMethodsHtml <- function() {
       tags$p("Below are some COVID-19 developments we are monitoring closely and are looking to incoporate into the methodology as data become available."),
       tags$ul(
         tags$li("Efficacy of vaccines at preventing severe COVID-19 outcomes including hospitalization, ICU admission, and death."),
-        tags$li("Risk of ", tags$a("post-COVID conditions", href = urls$cdc_post_covid_conditions), "for people with similar characteristic and behaviors as you")
+        tags$li("Risk of ", tags$a("post-COVID conditions", href = urls$cdc_post_covid_conditions), "for people with similar characteristics and behaviors as you")
         ) # end of ul 
       )# end of ul
   )

--- a/app/info_html.R
+++ b/app/info_html.R
@@ -134,7 +134,16 @@ renderMethodsHtml <- function() {
                adds 1 direct contact to the person's risk level." )
     ), # end of ol
     tags$p(""),
-    tags$p("We'll be doing our best to update these assumptions as additional knowledge about the virus becomes available.")
+    #tags$p("We'll be doing our best to update these assumptions as additional knowledge about the virus becomes available."),
+    tags$h4("In the Works [or Features/Updates to Come]"),
+    tags$ul(
+      tags$p("We are continuously working to update these assumptions as additional knowledge about the virus becomes available."),
+      tags$p("Below are some COVID-19 developments we are monitoring closely and are looking to incoporate into the methodology as data become available."),
+      tags$ul(
+        tags$li("Efficacy of vaccines at preventing severe COVID-19 outcomes including hospitalization, ICU admission, and death."),
+        tags$li("Risk of ", tags$a("post-COVID conditions", href = urls$cdc_post_covid_conditions), "for people with similar characteristic and behaviors as you")
+        ) # end of ul 
+      )# end of ul
   )
 }
 


### PR DESCRIPTION
Hi Cindy and Erin,

This pull request relates to adding information about [Post-COVID-19 Conditions](https://mathematicampr.atlassian.net/browse/C19ANDME-116) to the methods page.

Below is a draft of my idea for an "In the works" section at the end of the Methods page. 

![Capture](https://user-images.githubusercontent.com/22501112/118541187-6ddcfb00-b71f-11eb-8314-f498ed0d1878.JPG)

Please let me know what you think. For example:
- Do you think this a section worth having?
- What should the name and description of the section be?
- Are there any other features which should be included in the section?
