### PR TITLE
updated base image version

### DIFF
--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,5 +1,5 @@
 ARG AWS_ACCOUNT_ID
-FROM ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/shiny-verse-base-image
+FROM ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/shiny-verse-base-image:4.1.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
deployment failed due to incorrect shiny-verse base image version, updated to 4.1.0. 