### PR TITLE
fix: installation of renv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update \
     libgdal-dev \
     ca-certificates
 
-RUN R -e "install.packages(c('rlang','shiny', 'shinythemes', 'shinyjs', 'shinycssloaders', 'shinyBS', 'tidycensus' , 'assertr', 'flexdashboard', 'httr'), repos='http://cran.rstudio.com/')"
+RUN R -e "install.packages(c('rlang','shiny', 'shinythemes', 'shinyjs', 'shinycssloaders', 'shinyBS', 'tidycensus' , 'assertr', 'flexdashboard', 'httr', 'remotes'), repos='http://cran.rstudio.com/')"
 RUN R -e "install.packages('git2r', type='source', configure.vars='autobrew=yes')"
-RUN R -e "devtools::install_github('rstudio/renv')"
+RUN R -e "remotes::install_github('rstudio/renv')"
 RUN R -e "install.packages(c('aws.signature', 'aws.ec2metadata', 'aws.s3'), repos = c(cloudyr = 'http://cloudyr.github.io/drat', getOption('repos')))"
 
 COPY .Renviron .Renviron


### PR DESCRIPTION
Hi Cindy, 

This PR is to use the package `remotes` to install `renv`.
When I tried to run the RShiny app in the docker container, I got an error about the method for installing `renv` using `devtools`. The [renv website](https://rstudio.github.io/renv/articles/docker.html#creating-docker-images-with-renv) suggests using the `remotes` package to install `renv`. I made the change and was able to run the RShiny app from within the docker container.

Best wishes,
Emma